### PR TITLE
Fixed mistyped default shape in generated DOT

### DIFF
--- a/Refactoring.Pipelines.DotGraph/DotGraph/DotGraph.cs
+++ b/Refactoring.Pipelines.DotGraph/DotGraph/DotGraph.cs
@@ -14,7 +14,7 @@ namespace Refactoring.Pipelines.DotGraph
         public override string ToString()
         {
             return $@"
-digraph G {{ node [style=filled, shape=rec]
+digraph G {{ node [style=filled, shape=rect]
 
 # Nodes
 {nodes.JoinWith("")}

--- a/Refactoring.Pipelines.Test/_approvals/AsyncTest.ParallelRuns.approved.dot
+++ b/Refactoring.Pipelines.Test/_approvals/AsyncTest.ParallelRuns.approved.dot
@@ -1,4 +1,4 @@
-﻿digraph G { node [style=filled, shape=rec]
+﻿digraph G { node [style=filled, shape=rect]
 
 # Nodes
 "List<Int32> inputs" -> "_" -> "List<Int32>"

--- a/Refactoring.Pipelines.Test/_approvals/PipelineTests.ApplyTo.approved.dot
+++ b/Refactoring.Pipelines.Test/_approvals/PipelineTests.ApplyTo.approved.dot
@@ -1,4 +1,4 @@
-﻿digraph G { node [style=filled, shape=rec]
+﻿digraph G { node [style=filled, shape=rect]
 
 # Nodes
 {"String prefix", "Int32[] values"} -> "ApplyTo" -> {"List<Tuple<String, Int32>>", "Collector"}

--- a/Refactoring.Pipelines.Test/_approvals/PipelineTests.BasicPipelineTest.approved.dot
+++ b/Refactoring.Pipelines.Test/_approvals/PipelineTests.BasicPipelineTest.approved.dot
@@ -1,4 +1,4 @@
-﻿digraph G { node [style=filled, shape=rec]
+﻿digraph G { node [style=filled, shape=rect]
 
 # Nodes
 "String age" -> "Int64.Parse()" -> {"Int64", "Collector"}

--- a/Refactoring.Pipelines.Test/_approvals/PipelineTests.Cast.approved.dot
+++ b/Refactoring.Pipelines.Test/_approvals/PipelineTests.Cast.approved.dot
@@ -1,4 +1,4 @@
-﻿digraph G { node [style=filled, shape=rec]
+﻿digraph G { node [style=filled, shape=rect]
 
 # Nodes
 "Animal animal" -> "Cast<Dog>" -> "Dog"

--- a/Refactoring.Pipelines.Test/_approvals/PipelineTests.Concat.approved.dot
+++ b/Refactoring.Pipelines.Test/_approvals/PipelineTests.Concat.approved.dot
@@ -1,4 +1,4 @@
-﻿digraph G { node [style=filled, shape=rec]
+﻿digraph G { node [style=filled, shape=rect]
 
 # Nodes
 {"List<Int32> part1", "Int32[] part2"} -> "ConcatWith" -> {"List<Int32>", "Collector"}

--- a/Refactoring.Pipelines.Test/_approvals/PipelineTests.ConnectedPipelinesTest.approved.dot
+++ b/Refactoring.Pipelines.Test/_approvals/PipelineTests.ConnectedPipelinesTest.approved.dot
@@ -1,4 +1,4 @@
-﻿digraph G { node [style=filled, shape=rec]
+﻿digraph G { node [style=filled, shape=rect]
 
 # Nodes
 "String age" -> "Int64.Parse()" -> {"Int64", "Collector"}

--- a/Refactoring.Pipelines.Test/_approvals/PipelineTests.Flatten.approved.dot
+++ b/Refactoring.Pipelines.Test/_approvals/PipelineTests.Flatten.approved.dot
@@ -1,4 +1,4 @@
-﻿digraph G { node [style=filled, shape=rec]
+﻿digraph G { node [style=filled, shape=rect]
 
 # Nodes
 {"Tuple<Int64, Int64>", "Int64 value3"} -> "Join" -> "Tuple<Tuple<Int64, Int64>, Int64>"

--- a/Refactoring.Pipelines.Test/_approvals/PipelineTests.ForEach.approved.dot
+++ b/Refactoring.Pipelines.Test/_approvals/PipelineTests.ForEach.approved.dot
@@ -1,4 +1,4 @@
-﻿digraph G { node [style=filled, shape=rec]
+﻿digraph G { node [style=filled, shape=rect]
 
 # Nodes
 "List<Int64> part1" -> "Foreach(PipelineTests.IncrementLong())" -> {"List<Int64>", "Collector"}

--- a/Refactoring.Pipelines.Test/_approvals/PipelineTests.JoinInputs.approved.dot
+++ b/Refactoring.Pipelines.Test/_approvals/PipelineTests.JoinInputs.approved.dot
@@ -1,4 +1,4 @@
-﻿digraph G { node [style=filled, shape=rec]
+﻿digraph G { node [style=filled, shape=rect]
 
 # Nodes
 {"Int64 value1", "Int64 value2"} -> "Join" -> "Tuple<Int64, Int64>"

--- a/Refactoring.Pipelines.Test/_approvals/PipelineTests.JoinInputsSample.approved.dot
+++ b/Refactoring.Pipelines.Test/_approvals/PipelineTests.JoinInputsSample.approved.dot
@@ -1,4 +1,4 @@
-﻿digraph G { node [style=filled, shape=rec]
+﻿digraph G { node [style=filled, shape=rect]
 
 # Nodes
 {"Int64 value1", "Int64 value2"} -> "Join" -> "Tuple<Int64, Int64>"

--- a/Refactoring.Pipelines.Test/_approvals/PipelineTests.Lambda.approved.dot
+++ b/Refactoring.Pipelines.Test/_approvals/PipelineTests.Lambda.approved.dot
@@ -1,4 +1,4 @@
-﻿digraph G { node [style=filled, shape=rec]
+﻿digraph G { node [style=filled, shape=rect]
 
 # Nodes
 "Int32 input" -> "p.ToString()" -> "String"

--- a/Refactoring.Pipelines.Test/_approvals/PipelineTests.MultipleParameters.approved.dot
+++ b/Refactoring.Pipelines.Test/_approvals/PipelineTests.MultipleParameters.approved.dot
@@ -1,4 +1,4 @@
-﻿digraph G { node [style=filled, shape=rec]
+﻿digraph G { node [style=filled, shape=rect]
 
 # Nodes
 {"Int64 value1", "Int64 value2"} -> "Join" -> "Tuple<Int64, Int64>"

--- a/Refactoring.Pipelines.Test/_approvals/PipelineTests.SplitAndJoin.approved.dot
+++ b/Refactoring.Pipelines.Test/_approvals/PipelineTests.SplitAndJoin.approved.dot
@@ -1,4 +1,4 @@
-﻿digraph G { node [style=filled, shape=rec]
+﻿digraph G { node [style=filled, shape=rect]
 
 # Nodes
 "String age" -> "Int64.Parse()" -> "Int64"

--- a/Refactoring.Pipelines.Test/_approvals/PipelineTests.SplitInput.approved.dot
+++ b/Refactoring.Pipelines.Test/_approvals/PipelineTests.SplitInput.approved.dot
@@ -1,4 +1,4 @@
-﻿digraph G { node [style=filled, shape=rec]
+﻿digraph G { node [style=filled, shape=rect]
 
 # Nodes
 "Int64 value" -> "PipelineTests.LongToString()" -> "String"


### PR DESCRIPTION
In the DOT generation, the default shape was mistyped ("rec" instead of "rect"), causing a warning in the GraphViz library with the message "Warning: using box for unknown shape rec"