### PR TITLE
t   Removed flaky assert in async test

### DIFF
--- a/Refactoring.Pipelines.Test/AsyncTest.cs
+++ b/Refactoring.Pipelines.Test/AsyncTest.cs
@@ -36,7 +36,6 @@ namespace Refactoring.PipelinesAsync.Test
             var list2 = new ConcurrentBag<int>();
             inputPipe.Send(list1);
             inputPipe.Send(list2);
-            Assert.AreNotEqual(list1.ToReadableString(), list2.ToReadableString());
             Assert.AreEqual(list1.OrderBy(_ => _).ToReadableString(), list2.OrderBy(_ => _).ToReadableString());
 
             PipelineApprovals.Verify(inputPipe);


### PR DESCRIPTION
I looked at the CI build failures caused by the async test, and, besides the issues caused by thread safety, there was another one:
```csharp
Assert.AreNotEqual failed. Expected any value except:<[4, 1, 5, 6, 7, 2, 3]>. Actual:<[4, 1, 5, 6, 7, 2, 3]>. 
```
The issues is, even if adding to the list has random sleeps, there is still a chance for adding to happen in the same order twice, so I am removing the assert.