### PR TITLE
d   Update TODO

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -46,7 +46,6 @@ l
 - generate NuGet packages in CI
 - Run same tests against both Sync and Async APIs
 - Create CI for PipelinesExercise (use GitHub Actions to learn about them)
-- detect .dot errors like https://github.com/refactoring-pipelines/Pipelines/pull/67
 - ensure the library code invoked in async pipelines is thread-safe
   - tried HSR Parallel Checker (a free VS Extension) that promises it detects thread-unsafe code, however did not detect any problems on the solution (before the thread-safe fix was applied)
   - PostSharp Threading - costs money, need to investigate if it's useful


### PR DESCRIPTION
GraphVizNet NuGet package that is now referenced has an option to treat warnings as errors, and this option is explicitly set to true, so any warnings in the rendering will cause it to fail.